### PR TITLE
Fix: navigation was missing in Boost theme

### DIFF
--- a/classes/export.php
+++ b/classes/export.php
@@ -377,6 +377,10 @@ class export {
 
         // Remove any 'edit' links.
         $page->content = preg_replace('|<a href="edit\.php.*?\[edit]</a>|', '', $page->content);
+        $page->content = preg_replace('|<a href="edit\.php.*?\[Bearbeiten\]</a>|', '', $page->content);
+        $page->content = preg_replace('|<a href="edit\.php.*?\[modifica\]</a>|', '', $page->content);
+        $page->content = preg_replace('|<a href="edit\.php.*?\[Modifier\]</a>|', '', $page->content);
+        $page->content = preg_replace('|<a href="edit\.php.*?\[Editar\]</a>|', '', $page->content);
     }
 
     protected function start_export($download) {
@@ -497,12 +501,12 @@ class export {
         $imgel = \html_writer::empty_tag('img', array('src' => $img, 'style' => 'max-width: 90%;'));
         $html .= \html_writer::div($imgel, 'fronttitle', array('style' => 'text-align: center; padding: 1em 0;'));
         $html .= \html_writer::div(' ', 'fronttitletop', array('style' => 'display: block; width: 100%; height: 0.4em;
-                                                                               background-color: #b8cce4; margin-top: 1em;'));
-        $html .= \html_writer::tag('h1', $title, array('style' => 'display: block; width: 100%; background-color: #4f81bd;
+                                                                               background-color: #4b647d; margin-top: 1em;'));
+        $html .= \html_writer::tag('h1', $title, array('style' => 'display: block; width: 100%; background-color: #ffffff;
                                                                   min-height: 2em; text-align: center; padding-top: 0.5em;
                                                                   size: 1em; margin: 0;' ));
         $html .= \html_writer::div(' ', 'fronttitlebottom', array('style' => 'display: block; width: 100%; height: 0.4em;
-                                                                               background-color: #4bacc6; margin-bottom: 1em;'));
+                                                                               background-color: #4b647d; margin-bottom: 1em;'));
         $html .= \html_writer::div($description, 'frontdescription', array('style' => 'margin: 0.5em 1em;'));
         $html .= \html_writer::div($info, 'frontinfo', array('style' => 'margin: 2em 1em'));
 
@@ -517,16 +521,17 @@ class export {
 
         $exp->startPage();
         // Rounded rectangle.
-        $exp->RoundedRect(9, 9, 192, 279, 6.5);
+        // $exp->RoundedRect(9, 9, 192, 279, 6.5);
         // Logo.
         $exp->Image($CFG->dirroot.'/local/wikiexport/pix/logo.png', 52, 27, 103, 36);
         // Title bar.
-        $exp->Rect(9, 87.5, 192, 2.5, 'F', array(), array(184, 204, 228));
-        $exp->Rect(9, 90, 192, 30, 'F', array(), array(79, 129, 189));
-        $exp->Rect(9, 120, 192, 2.5, 'F', array(), array(75, 172, 198));
+        $exp->Rect(9, 87.5, 192, 2.5, 'F', array(), array(75, 100, 125));
+        $exp->Rect(9, 90, 192, 30, 'F', array(), array(255, 255, 255));
+        $exp->Rect(9, 120, 192, 2.5, 'F', array(), array(75, 100, 125));
 
         // Title text.
         $title = $this->wiki->name;
+        $exp->SetFont('freesans', '', 12, '', false);
         $exp->SetFontSize(36);
         $exp->Text(9, 97, $title, false, false, true, 0, 0, 'C', false, '', 1, false, 'T', 'C');
         $exp->SetFontSize(12); // Set back to default.

--- a/classes/export.php
+++ b/classes/export.php
@@ -376,11 +376,7 @@ class export {
         }
 
         // Remove any 'edit' links.
-        $page->content = preg_replace('|<a href="edit\.php.*?\[edit]</a>|', '', $page->content);
-        $page->content = preg_replace('|<a href="edit\.php.*?\[Bearbeiten\]</a>|', '', $page->content);
-        $page->content = preg_replace('|<a href="edit\.php.*?\[modifica\]</a>|', '', $page->content);
-        $page->content = preg_replace('|<a href="edit\.php.*?\[Modifier\]</a>|', '', $page->content);
-        $page->content = preg_replace('|<a href="edit\.php.*?\[Editar\]</a>|', '', $page->content);
+        $page->content = preg_replace('|<a href="edit\.php.*?\[[^\]]*\]</a>|', '', $page->content);
     }
 
     protected function start_export($download) {

--- a/classes/export.php
+++ b/classes/export.php
@@ -393,10 +393,9 @@ class export {
             $exp->set_publisher(get_string('publishername', 'local_wikiexport'));
         } else { // PDF.
             $exp = new export_pdf();
-            $restricttocontext = false;
-            if ($download) {
-                $restricttocontext = \context_module::instance($this->cm->id);
-            }
+            $exp->SetCreator(PDF_CREATOR);
+            $exp->SetTitle($this->wiki->name);
+            $restricttocontext = $download ? \context_module::instance($this->cm->id) : false;
             $exp->use_direct_image_load($restricttocontext);
             $exp->SetMargins(20, 10, -1, true); // Set up wider left margin than default.
         }

--- a/classes/export_epub.php
+++ b/classes/export_epub.php
@@ -47,8 +47,12 @@ class export_epub extends \LuciEPUB {
                         $file->get_itemid(), $file->get_filepath(), $file->get_filename(),
                     ]);
                     $newpath = str_replace(['///', '//'], '/', $newpath);
-                    $this->add_item_file($file->get_content_file_handle(), $file->get_mimetype(), $newpath);
-                    $html = str_replace($imageurl, $newpath, $html);
+                    try {
+                        $this->add_item_file($file->get_content_file_handle(), $file->get_mimetype(), $newpath);
+                        $html = str_replace($imageurl, $newpath, $html);
+                    } catch (\Exception $e) {
+                        continue;
+                    }
                 }
             }
         }

--- a/db/access.php
+++ b/db/access.php
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 /**
  * Capability definitions
  *
@@ -21,7 +21,7 @@
  * @copyright 2014 Davo Smith, Synergy Learning
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
- 
+
 defined('MOODLE_INTERNAL') || die();
 
 $capabilities = array(

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -113,5 +113,5 @@ function xmldb_local_wikiexport_upgrade($oldversion = 0) {
         upgrade_plugin_savepoint(true, 2015071300, 'local', 'wikiexport');
     }
 
-   return true;
+    return true;
 }

--- a/lib.php
+++ b/lib.php
@@ -27,14 +27,11 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Insert the 'Export as epub' and 'Export as PDF' links into the navigation.
  *
- * @param $unused
+ * @param navigation_node $settingsnav
  */
-function local_wikiexport_extends_navigation($unused) {
-    local_wikiexport_extend_navigation($unused);
-}
-
-function local_wikiexport_extend_navigation($unused) {
+function local_wikiexport_extend_settings_navigation(navigation_node $settingsnav) {
     global $PAGE, $DB, $USER;
+
     if (!$PAGE->cm || $PAGE->cm->modname !== 'wiki') {
         return;
     }
@@ -54,23 +51,14 @@ function local_wikiexport_extend_navigation($unused) {
     if (!$links = \local_wikiexport\export::get_links($PAGE->cm, $userid, $groupid)) {
         return;
     }
-    $settingsnav = $PAGE->settingsnav;
-    $modulesettings = $settingsnav->get('modulesettings');
+    $modulesettings = $settingsnav->find('modulesettings', navigation_node::TYPE_SETTING);
     if (!$modulesettings) {
-        $modulesettings = $settingsnav->prepend(get_string('pluginadministration', 'mod_wiki'), null,
-                                                navigation_node::TYPE_SETTING, null, 'modulesettings');
+        $modulesettings = $settingsnav->add(
+            get_string('pluginadministration', 'mod_wiki'), null,
+            navigation_node::TYPE_SETTING, null, 'modulesettings');
     }
 
     foreach ($links as $name => $url) {
         $modulesettings->add($name, $url, navigation_node::TYPE_SETTING);
     }
-
-    // Use javascript to insert the pdf/epub links.
-    $jslinks = array();
-    foreach ($links as $name => $url) {
-        $link = html_writer::link($url, $name);
-        $link = html_writer::div($link, 'wiki_right');
-        $jslinks[] = $link;
-    }
-    $PAGE->requires->yui_module('moodle-local_wikiexport-printlinks', 'M.local_wikiexport.printlinks.init', array($jslinks));
 }

--- a/luciepub/LuciEPUB.php
+++ b/luciepub/LuciEPUB.php
@@ -38,6 +38,9 @@ class LuciEPUB {
     protected $counter = 1;
     protected $extra = array();
 
+    protected $items = [];
+    protected $headers = [];
+
     protected function generate_id($spine = FALSE) {
 	if ($spine)
 	    return 'luci' . $this->spine_counter++;

--- a/luciepub/LuciZip.php
+++ b/luciepub/LuciZip.php
@@ -406,7 +406,7 @@ class LuciZip {
      * @return bool $success
      */
     public function closeStream() {
-        if ($this->isFinalized || strlen($this->streamFilePath) == 0) {
+        if ($this->isFinalized || !$this->streamFilePath) {
             return FALSE;
         }
 
@@ -487,7 +487,7 @@ class LuciZip {
      */
     public function finalize() {
         if (!$this->isFinalized) {
-            if (strlen($this->streamFilePath) > 0) {
+            if (!$this->streamFilePath) {
                 $this->closeStream();
             }
             $cd = implode("", $this->cdRec);

--- a/settings.php
+++ b/settings.php
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
- 
+
 /**
  * Global settings
  *
@@ -21,7 +21,7 @@
  * @copyright 2014 Davo Smith, Synergy Learning
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
- 
+
 defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {

--- a/settings.php
+++ b/settings.php
@@ -26,6 +26,8 @@ defined('MOODLE_INTERNAL') || die();
 
 if ($hassiteconfig) {
     if (!$page = $ADMIN->locate('modsettingwiki')) {
+        $lang = current_language();
+        $collator = new \Collator($lang);
         // No settings page exists for the wiki - add it.
         $wikiname = get_string('pluginname', 'wiki');
         $page = new admin_settingpage('modsettingwiki', $wikiname);
@@ -34,7 +36,8 @@ if ($hassiteconfig) {
         $beforesibling = null;
         $modules = $ADMIN->locate('modsettings');
         foreach ($modules->children as $module) {
-            if (strcmp($module->visiblename, $wikiname) > 0) {
+            $visiblename = ($module->visiblename instanceof lang_string) ? $module->visiblename->out(false) : $module->visiblename;
+            if ($collator->compare($visiblename, $wikiname) > 0) {
                 $beforesibling = $module->name;
                 break;
             }

--- a/tests/export_test.php
+++ b/tests/export_test.php
@@ -62,4 +62,37 @@ class export_test extends \advanced_testcase {
 
         $this->assertEmpty($emails);
     }
+
+    public function test_format_line_breaks_for_html(): void {
+        global $USER;
+
+        $gen = self::getDataGenerator();
+        /** @var \mod_wiki_generator $wgen */
+        $wgen = $gen->get_plugin_generator('mod_wiki');
+
+        self::setAdminUser();
+        $c1 = $gen->create_course();
+        $w1 = $wgen->create_instance(['course' => $c1->id, 'name' => 'Example wiki']);
+        self::setUser();
+        $export = new \local_wikiexport\export($w1->cmid, $w1, 'epub', $USER, null);
+    
+        $reflectionMethod = new \ReflectionMethod(get_class($export), 'format_line_breaks_for_html');
+        $reflectionMethod->setAccessible(true);
+        $this->assertEquals(
+            'The cat page ',
+            $reflectionMethod->invokeArgs($export, ["The\r\ncat page\n"])
+        );
+        $this->assertEquals(
+            "This is the <code>\ndog\n  inner 1\n/dog\n</code>page",
+            $reflectionMethod->invokeArgs($export, ["This is the <code>\ndog\n  inner 1\n/dog\n</code>page"])
+        );
+        $this->assertEquals(
+            "Some Code: <pre><code>\nimport os\n\nprint('foo bar')\n</code></pre> Fig. 1",
+            $reflectionMethod->invokeArgs($export, ["Some Code:\n<pre><code>\nimport os\n\nprint('foo bar')\n</code></pre>\nFig. 1"])
+        );
+        $this->assertEquals(
+            "Some Code: <pre><code data-lang=\"python\">\nimport os\n\nprint('foo bar')\n</code></pre> Fig. 1",
+            $reflectionMethod->invokeArgs($export, ["Some Code: <pre><code data-lang=\"python\">\nimport os\n\nprint('foo bar')\n</code></pre> Fig. 1"])
+        );
+    }
 }


### PR DESCRIPTION
When using the boost theme, the three menu items:
* Export to epub
* Export to pdf
* Sort pages

did not appear anywhere. The user was only able to export the wiki with the classic theme. The hook method was changed now so that for both themes the same mechanism works to inject the menu items.